### PR TITLE
fix missingvariantexception for stemcrops

### DIFF
--- a/src/main/java/com/eerussianguy/firmalife/registry/VanillaStemStateMapper.java
+++ b/src/main/java/com/eerussianguy/firmalife/registry/VanillaStemStateMapper.java
@@ -53,10 +53,18 @@ public class VanillaStemStateMapper extends StateMapperBase
         map.remove(block.getStageProperty());
 
         //spoof a vanilla melon's blockstate
-        if(vanillaAge >= 0) {
+        if(vanillaAge >= 0)
+        {
             map.put(BlockStem.AGE, vanillaAge);
             map.remove(BlockStemCrop.FACING); //needed to get correct insertion order
             map.put(BlockStemCrop.FACING, EnumFacing.UP);
+        }
+        else if(map.get(BlockStemCrop.FACING) == EnumFacing.UP)
+        {
+            //this should never happen in reality but it is a possible blockstate
+            //so we have to include something here so that we don't get
+            //missing variant errors
+            map.put(BlockStemCrop.FACING, EnumFacing.NORTH);
         }
         //if vanillaAge is -1, then the crop is fully grown, so it keeps only the FACING property
 


### PR DESCRIPTION
Stemcrops always point in a horizontal direction. However, their blockstate allows for pointing up or down, as a a potential for subclasses (e.g. if they determine growth later on in the life cycle and need to point "up" until a direction is determined) which means that pointing up is a possible blockstate. The vanilla state mapper overwrites the direction for immature crops, so it doesn't matter either way for those. However for mature crops, there was a missing variant exception for facing up (even though currently this never happens) so we just put in arbitrary data to make the registry happy.