### PR TITLE
Fixed vat recipes, closes #192

### DIFF
--- a/src/main/java/com/eerussianguy/firmalife/common/recipes/VatRecipe.java
+++ b/src/main/java/com/eerussianguy/firmalife/common/recipes/VatRecipe.java
@@ -134,7 +134,7 @@ public class VatRecipe implements ISimpleRecipe<VatBlockEntity.VatInventory>
         return inputItem.test(container.getStackInSlot(0))
             && inputFluid.test(container.getFluidInTank(0))
             && (inputFluid.amount() == 0
-            || outputFluid.getAmount() == 0
+            || inputItem.count() == 0
             || (inputItem.count() > 0 && inputFluid.amount() > 0 && container.getFluidInTank(0).getAmount() / this.inputFluid.amount() <= container.getStackInSlot(0).getCount() / this.inputItem.count())
             );
     }


### PR DESCRIPTION
All test cases in #192 now pass. Changed outputFluid.getAmount() == 0 to inputItem.count() == 0 in vat recipe's matches() method.