### PR TITLE
Fix pumping station not accepting negative rotation speeds

### DIFF
--- a/src/main/java/com/eerussianguy/firmalife/common/blockentities/PumpingStationBlockEntity.java
+++ b/src/main/java/com/eerussianguy/firmalife/common/blockentities/PumpingStationBlockEntity.java
@@ -42,7 +42,7 @@ public class PumpingStationBlockEntity extends TFCBlockEntity implements Rotatio
     public boolean isPumping()
     {
         assert level != null;
-        if ((node.rotation() != null && node.rotation().speed() > 0f) || (FLConfig.SERVER.mechanicalPowerCheatMode.get() && level.getDirectSignalTo(worldPosition) > 0))
+        if ((node.rotation() != null && node.rotation().positiveSpeed() > 0f) || (FLConfig.SERVER.mechanicalPowerCheatMode.get() && level.getDirectSignalTo(worldPosition) > 0))
         {
             final BlockState state = level.getBlockState(worldPosition.below());
             return state.getFluidState().getType() == Fluids.WATER || state.getBlock() instanceof RiverWaterBlock;


### PR DESCRIPTION
The pumping station currently checks if its rotation speed is > 0, which means it doesn't work with negative rotation speeds. Negative rotation speeds are intended to be able to power blocks in TFC, blocks such as the quern and FirmaLife's compost tumbler can handle negative rotations.
This PR replaces the pumping station's call to `node.rotation().speed()` with a call to `node.rotation.positiveSpeed()`, which takes the absolute value and fixes the bug.

(this was such a pain to figure out)