### PR TITLE
Fix Top Oven extinguish() not properly resetting state

### DIFF
--- a/src/main/java/com/eerussianguy/firmalife/common/blockentities/OvenTopBlockEntity.java
+++ b/src/main/java/com/eerussianguy/firmalife/common/blockentities/OvenTopBlockEntity.java
@@ -270,7 +270,7 @@ public class OvenTopBlockEntity extends ApplianceBlockEntity<ApplianceBlockEntit
 
     public void extinguish()
     {
-        for (int i = SLOT_INPUT_START; i < SLOT_INPUT_END; i++)
+        for (int i = SLOT_INPUT_START; i <= SLOT_INPUT_END; i++)
         {
             cookTicks[i] = 0;
             cachedRecipes[i] = null;


### PR DESCRIPTION
`public static final int SLOT_INPUT_END = 3;`
`cookTicks = new int[] {0, 0, 0, 0};`
`cachedRecipes = new WrappedHeatingRecipe[4];`

It was not resetting slot 3's state.