### PR TITLE
Fix Top Oven extinguish() not properly resetting state

### DIFF
--- a/src/main/java/com/eerussianguy/firmalife/common/blockentities/OvenTopBlockEntity.java
+++ b/src/main/java/com/eerussianguy/firmalife/common/blockentities/OvenTopBlockEntity.java
@@ -241,7 +241,7 @@ public class OvenTopBlockEntity extends ApplianceBlockEntity<ApplianceBlockEntit
 
     public void extinguish()
     {
-        for (int i = SLOT_INPUT_START; i < SLOT_INPUT_END; i++)
+        for (int i = SLOT_INPUT_START; i <= SLOT_INPUT_END; i++)
         {
             cookTicks[i] = 0;
             cachedRecipes[i] = null;


### PR DESCRIPTION
Same as the other PR but for 1.20.x

The bug is also on the 1.18.x branch, not sure if I'm meant to open a PR for it too, I do not want to spam.